### PR TITLE
Update build mode and Vite configuration for production

### DIFF
--- a/.github/workflows/homepage-deploy.yml
+++ b/.github/workflows/homepage-deploy.yml
@@ -35,7 +35,7 @@ jobs:
     - run: npm ci
 
     - name: Build
-      run: npx nx build @senthanal/homepage --prod
+      run: npx nx build @senthanal/homepage --mode production
 
     - name: Upload static files as artifact
       id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -72,13 +72,6 @@ web_modules/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variable files
-.env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
-
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/homepage/vite.config.ts
+++ b/homepage/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: process.env.NODE_ENV === 'production' ? '/homepage/' : '/',
   root: __dirname,
   cacheDir: '../node_modules/.vite/homepage',
   server: {


### PR DESCRIPTION
Adjust the build command to use production mode and update the Vite configuration to set the base path for production. Clean up unnecessary dotenv files from the repository.